### PR TITLE
WC-715 진료 조회

### DIFF
--- a/wanchcoach/src/main/java/com/wanchcoach/domain/drug/entity/Drug.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/drug/entity/Drug.java
@@ -15,8 +15,8 @@ public class Drug extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "drug_id")
-    private Long id;
+    @Column
+    private Long drugId;
 
     @Column(nullable = false)
     private String name;

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/drug/repository/query/DrugQueryRepository.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/drug/repository/query/DrugQueryRepository.java
@@ -30,7 +30,7 @@ public class DrugQueryRepository {
     public Drug findById(Long drugId) {
         return queryFactory
                 .selectFrom(drug)
-                .where(drug.id.eq(drugId))
+                .where(drug.drugId.eq(drugId))
                 .fetchOne();
     }
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/family/entity/Family.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/family/entity/Family.java
@@ -24,8 +24,8 @@ public class Family extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "family_id")
-    private Long id;
+    @Column
+    private Long familyId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/family/repository/query/FamilyQueryRepository.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/family/repository/query/FamilyQueryRepository.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 import static com.wanchcoach.domain.family.entity.QFamily.family;
 
 @Slf4j
@@ -25,15 +27,37 @@ public class FamilyQueryRepository {
     public Family findById(Long familyId) {
         return queryFactory
                 .selectFrom(family)
-                .where(family.id.eq(familyId))
+                .where(family.familyId.eq(familyId))
                 .fetchOne();
     }
 
+    /**
+     *
+     * 가족 ID로 이름 조회 쿼리
+     *
+     * @param familyId 가족 ID
+     * @return 해당 가족 이름
+     */
     public String findNameById(Long familyId) {
         return queryFactory
                 .select(family.name)
                 .from(family)
-                .where(family.id.eq(familyId))
+                .where(family.familyId.eq(familyId))
                 .fetchOne();
+    }
+
+    /**
+     *
+     * 회원 ID로 등록된 전체 가족 ID 조회
+     *
+     * @param memberId 회원 ID
+     * @return 해당 회원에 등록된 가족 ID 목록
+     */
+    public List<Long> findFamilyIdsByMemberId(Long memberId) {
+        return queryFactory
+                .selectDistinct(family.familyId)
+                .from(family)
+                .where(family.member.memberId.eq(memberId))
+                .fetch();
     }
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/medical/entity/Hospital.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/medical/entity/Hospital.java
@@ -23,8 +23,8 @@ public class Hospital extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "hospital_id")
-    private Long id;
+    @Column
+    private Long hospitalId;
 
     @Column(nullable = false)
     private String name;
@@ -42,8 +42,5 @@ public class Hospital extends BaseEntity {
     private BigDecimal latitude;
 
     @Column(nullable = false)
-    private Integer postCdn1;
-
-    @Column(nullable = false)
-    private Integer postCdn2;
+    private String postCdn;
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/medical/entity/Pharmacy.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/medical/entity/Pharmacy.java
@@ -24,7 +24,7 @@ public class Pharmacy extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "pharmacy_id")
-    private Long id;
+    private Long pharmacyId;
 
     @Column(nullable = false)
     private String name;
@@ -42,8 +42,5 @@ public class Pharmacy extends BaseEntity {
     private BigDecimal latitude;
 
     @Column(nullable = false)
-    private Integer postCdn1;
-
-    @Column(nullable = false)
-    private Integer postCdn2;
+    private String postCdn;
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/medical/repository/query/HospitalQueryRepository.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/medical/repository/query/HospitalQueryRepository.java
@@ -30,7 +30,7 @@ public class HospitalQueryRepository {
     public Hospital findById(Long hospitalId) {
         return queryFactory
                 .selectFrom(hospital)
-                .where(hospital.id.eq(hospitalId))
+                .where(hospital.hospitalId.eq(hospitalId))
                 .fetchOne();
     }
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/medical/repository/query/PharmacyQueryRepository.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/medical/repository/query/PharmacyQueryRepository.java
@@ -30,7 +30,7 @@ public class PharmacyQueryRepository {
     public Pharmacy findById(Long pharmacyId) {
         return queryFactory
                 .selectFrom(pharmacy)
-                .where(pharmacy.id.eq(pharmacyId))
+                .where(pharmacy.pharmacyId.eq(pharmacyId))
                 .fetchOne();
     }
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/TreatmentController.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/TreatmentController.java
@@ -2,9 +2,8 @@ package com.wanchcoach.domain.treatment.controller;
 
 import com.wanchcoach.domain.treatment.controller.request.CreatePrescriptionRequest;
 import com.wanchcoach.domain.treatment.controller.request.CreateTreatmentRequest;
-import com.wanchcoach.domain.treatment.controller.response.CreatePrescriptionResponse;
-import com.wanchcoach.domain.treatment.controller.response.CreateTreatmentResponse;
-import com.wanchcoach.domain.treatment.repository.query.TreatmentQueryRepository;
+import com.wanchcoach.domain.treatment.controller.response.*;
+import com.wanchcoach.domain.treatment.service.TreatmentQueryService;
 import com.wanchcoach.domain.treatment.service.TreatmentService;
 import com.wanchcoach.domain.treatment.service.dto.CreatePrescriptionDto;
 import com.wanchcoach.domain.treatment.service.dto.CreateTreatmentDto;
@@ -30,7 +29,7 @@ public class TreatmentController {
 
     private final TreatmentService treatmentService;
     private final String urlPrefix = "https://objectstorage.ap-chuncheon-1.oraclecloud.com";
-    private final TreatmentQueryRepository treatmentQueryRepository;
+    private final TreatmentQueryService treatmentQueryService;
 
     /**
      * 진료 등록 API
@@ -45,7 +44,7 @@ public class TreatmentController {
                                                               @RequestPart MultipartFile file) throws Exception {
 
         log.info("TreatmentController#createTreatment called");
-        // todo 이메일 정보 가져와서 계정 - 가족 정보 유효한지 확인
+        // todo: 토큰 정보 가져와서 회원 ID 가져오기, 계정-가족 정보 유효한지 확인
 
 
         // 진료 정보 저장
@@ -88,7 +87,6 @@ public class TreatmentController {
      * @param file 처방전 이미지 파일
      * @return 등록한 처방전 ID
      */
-
     @PostMapping("/{treatmentId}/prescription")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResult<CreatePrescriptionResponse> createPrescription(@PathVariable Long treatmentId,
@@ -96,7 +94,9 @@ public class TreatmentController {
                                                                     @RequestPart(required = false) MultipartFile file) throws Exception {
         log.info("TreatmentController#createPrescription called");
 
-        // todo 이메일 정보 가져와서 계정 - 가족 정보 유효한지 확인
+        // todo: todo: 토큰 정보 가져와서 회원 ID 가져오기, 계정-가족 정보 유효한지 확인
+
+
         CreatePrescriptionResponse response = treatmentService.createPrescription(CreatePrescriptionDto.of(
                 prescriptionRequest.familyId(),
                 prescriptionRequest.pharmacyId(),
@@ -109,4 +109,118 @@ public class TreatmentController {
 
         return ApiResult.OK(response);
     }
+
+    /**
+     * 전체 가족 진료 조회 API
+     *
+     * @return 전체 가족 진료 정보
+     */
+    @GetMapping
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ApiResult<TreatmentResponse> getTreatments() {
+        log.info("TreatmentController#getTreatments called");
+
+        // todo: 토큰 정보 가져와서 회원 ID 가져오기
+        Long memberId = 1L;
+
+        TreatmentResponse response = treatmentQueryService.getTreatments(memberId);
+
+        return ApiResult.OK(response);
+    }
+
+    /**
+     * 가족 진료 조회 API
+     *
+     * @param familyId 조회할 가족 ID
+     * @return 가족 진료 정보
+     */
+    @GetMapping("/families/{familyId}")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ApiResult<TreatmentResponse> getFamilyTreatments(@PathVariable Long familyId) {
+        log.info("TreatmentController#getTreatmentByFamilyId called");
+
+        // todo: 토큰 정보 가져와서 회원 ID 가져오기, 계정-가족 정보 유효한지 확인
+        Long memberId = 1L;
+
+        TreatmentResponse response = treatmentQueryService.getFamilyTreatments(familyId);
+
+        return ApiResult.OK(response);
+    }
+
+    /**
+     * 전체 가족 진료 병원별 조회 API
+     *
+     * @return 전체 가족 병원별 진료 정보
+     */
+    @GetMapping("/hospitals")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ApiResult<TreatmentHospitalResponse> getTreatmentsByHospital() {
+        log.info("TreatmentController#getTreatmentsByHospital called");
+
+        // todo: 토큰 정보 가져와서 회원 ID 가져오기
+        Long memberId = 1L;
+
+        TreatmentHospitalResponse response = treatmentQueryService.getTreatmentsByHospital(memberId);
+
+        return ApiResult.OK(response);
+    }
+
+    /**
+     * 가족 진료 병원별 조회 API
+     *
+     * @param familyId 조회할 가족 ID
+     * @return 가족 병원별 진료 정보
+     */
+    @GetMapping("/hospitals/families/{familyId}")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ApiResult<TreatmentHospitalResponse> getFamilyTreatmentsByHospital(@PathVariable Long familyId) {
+        log.info("TreatmentController#getFamilyTreatmentsByHospital called");
+
+        // todo: 토큰 정보 가져와서 회원 ID 가져오기, 계정-가족 정보 유효한지 확인
+        Long memberId = 1L;
+
+        TreatmentHospitalResponse response = treatmentQueryService.getFamilyTreatmentsByHospital(familyId);
+
+        return ApiResult.OK(response);
+    }
+
+    /**
+     * 전체 가족 진료 월별 조회 API
+     *
+     * @param year 조회할 연도
+     * @param month 조회할 달
+     * @return 전체 가족 월별 진료 정보
+     */
+    @GetMapping("/date")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ApiResult<TreatmentDateResponse> getTreatmentsByDate(@RequestParam Integer year, @RequestParam Integer month) {
+        log.info("TreatmentController#getTreatmentsByDate called");
+
+        // todo: 토큰 정보 가져와서 회원 ID 가져오기
+        Long memberId = 1L;
+
+        TreatmentDateResponse response = treatmentQueryService.getTreatmentsByDate(memberId, year, month);
+        return ApiResult.OK(response);
+    }
+
+    /**
+     * 가족 진료 월별 조회 API
+     *
+     * @param familyId 조회할 가족 ID
+     * @param year 조회할 연도
+     * @param month 조회할 달
+     * @return 가족 월별 진료 정보
+     */
+    @GetMapping("/date/families/{familyId}")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ApiResult<TreatmentDateResponse> getFamilyTreatmentsByDate(@PathVariable Long familyId, @RequestParam Integer year, @RequestParam Integer month) {
+        log.info("TreatmentController#getFamilyTreatmentsByDate called");
+
+        // todo: 토큰 정보 가져와서 회원 ID 가져오기, 계정-가족 정보 유효한지 확인
+        Long memberId = 1L;
+
+        TreatmentDateResponse response = treatmentQueryService.getFamilyTreatmentsByDate(familyId, year, month);
+        return ApiResult.OK(response);
+    }
+
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentDateItem.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentDateItem.java
@@ -1,0 +1,14 @@
+package com.wanchcoach.domain.treatment.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class TreatmentDateItem {
+    private LocalDate date;
+    private List<TreatmentItem> treatmentItems;
+}

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentDateResponse.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentDateResponse.java
@@ -1,0 +1,6 @@
+package com.wanchcoach.domain.treatment.controller.response;
+
+import java.util.List;
+
+public record TreatmentDateResponse(List<TreatmentDateItem> treatmentDateItems) {
+}

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentHospitalItem.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentHospitalItem.java
@@ -1,0 +1,14 @@
+package com.wanchcoach.domain.treatment.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class TreatmentHospitalItem {
+    Long hospitalId;
+    String hospitalName;
+    List<TreatmentItem> treatmentItems;
+}

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentHospitalResponse.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentHospitalResponse.java
@@ -1,0 +1,6 @@
+package com.wanchcoach.domain.treatment.controller.response;
+
+import java.util.List;
+
+public record TreatmentHospitalResponse(List<TreatmentHospitalItem> treatmentHospitalItems) {
+}

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentItem.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentItem.java
@@ -1,0 +1,28 @@
+package com.wanchcoach.domain.treatment.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class TreatmentItem implements Comparable<TreatmentItem> {
+
+    private Long id;
+    private Long familyId;
+    private String familyName;
+    private Long hospitalId;
+    private String hospitalName;
+    private Long prescriptionId;
+    private String department;
+    private LocalDateTime date;
+    private Boolean taken;
+    private Boolean alarm;
+    private String symptom;
+
+    @Override
+    public int compareTo(TreatmentItem o) {
+        return o.date.compareTo(this.date);
+    }
+}

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentResponse.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/controller/response/TreatmentResponse.java
@@ -1,0 +1,6 @@
+package com.wanchcoach.domain.treatment.controller.response;
+
+import java.util.List;
+
+public record TreatmentResponse(List<TreatmentItem> upcoming, List<TreatmentItem> past) {
+}

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/entity/Prescription.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/entity/Prescription.java
@@ -24,8 +24,8 @@ public class Prescription extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "prescription_id")
-    private Long id;
+    @Column
+    private Long prescriptionId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pharmacy_id", nullable = false)

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/entity/Treatment.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/entity/Treatment.java
@@ -25,8 +25,8 @@ public class Treatment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "treatment_id")
-    private Long id;
+    @Column
+    private Long treatmentId;
 
      @ManyToOne(fetch = FetchType.LAZY)
      @JoinColumn(name = "family_id", nullable = false)

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/repository/query/PrescriptionQueryRepository.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/repository/query/PrescriptionQueryRepository.java
@@ -30,7 +30,7 @@ public class PrescriptionQueryRepository {
     public Prescription findById(Long prescriptionId) {
         return queryFactory
                 .selectFrom(prescription)
-                .where(prescription.id.eq(prescriptionId))
+                .where(prescription.prescriptionId.eq(prescriptionId))
                 .fetchOne();
     }
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/repository/query/TreatmentQueryRepository.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/repository/query/TreatmentQueryRepository.java
@@ -1,11 +1,18 @@
 package com.wanchcoach.domain.treatment.repository.query;
 
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanchcoach.domain.treatment.controller.response.TreatmentItem;
 import com.wanchcoach.domain.treatment.entity.Treatment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.wanchcoach.domain.treatment.entity.QTreatment.treatment;
 
@@ -31,22 +38,221 @@ public class TreatmentQueryRepository {
     public Treatment findById(Long treatmentId) {
         return queryFactory
                 .selectFrom(treatment)
-                .where(treatment.id.eq(treatmentId))
+                .where(treatment.treatmentId.eq(treatmentId))
                 .fetchOne();
     }
 
     /**
-     * 처방전 ID로 가족 ID 조회 쿼리
+     * 회원 ID로 전체 가족의 진료 조회 쿼리
      *
-     * @param prescriptionId 처방전 ID
-     * @return 가족 ID
+     * @param memberId 회원 ID
+     * @param isUpcoming 예정된 진료 여부
+     * @return 모든 진료 정보
      */
-    public Long findFamilyIdByPrescriptionId(Long prescriptionId) {
-//        return queryFactory
-//                .select(treatment.familyId)
-//                .from(treatment)
-//                .where(treatment.prescription.id.eq(prescriptionId))
-//                .fetchOne();
-        return null;
+    public List<TreatmentItem> findTreatments(Long memberId, Boolean isUpcoming) {
+        if (isUpcoming) {
+            return queryFactory
+                    .select(Projections.constructor(TreatmentItem.class,
+                            treatment.treatmentId,
+                            treatment.family.familyId,
+                            treatment.family.name,
+                            treatment.hospital.hospitalId,
+                            treatment.hospital.name,
+                            treatment.prescription.prescriptionId,
+                            treatment.department,
+                            treatment.date,
+                            treatment.taken,
+                            treatment.alarm,
+                            treatment.symptom))
+                    .from(treatment)
+                    .where(treatment.family.member.memberId.eq(memberId),
+                            treatment.date.goe(LocalDateTime.now())
+                    )
+                    .orderBy(treatment.date.desc())
+                    .fetch();
+        } else {
+            return queryFactory
+                    .select(Projections.constructor(TreatmentItem.class,
+                            treatment.treatmentId,
+                            treatment.family.familyId,
+                            treatment.family.name,
+                            treatment.hospital.hospitalId,
+                            treatment.hospital.name,
+                            treatment.prescription.prescriptionId,
+                            treatment.department,
+                            treatment.date,
+                            treatment.taken,
+                            treatment.alarm,
+                            treatment.symptom))
+                    .from(treatment)
+                    .where(treatment.family.member.memberId.eq(memberId),
+                            treatment.date.lt(LocalDateTime.now())
+                    )
+                    .orderBy(treatment.date.desc())
+                    .fetch();
+        }
+    }
+
+    /**
+     * 가족 ID로 전체 진료 조회 쿼리
+     *
+     * @param familyId 가족 ID
+     * @param isUpcoming 예정된 진료 여부
+     * @return 모든 진료 정보
+     */
+    public List<TreatmentItem> findFamilyTreatments(Long familyId, Boolean isUpcoming) {
+        if (isUpcoming) {
+            return queryFactory
+                    .select(Projections.constructor(TreatmentItem.class,
+                            treatment.treatmentId,
+                            treatment.family.familyId,
+                            treatment.family.name,
+                            treatment.hospital.hospitalId,
+                            treatment.hospital.name,
+                            treatment.prescription.prescriptionId,
+                            treatment.department,
+                            treatment.date,
+                            treatment.taken,
+                            treatment.alarm,
+                            treatment.symptom))
+                    .from(treatment)
+                    .where(treatment.family.familyId.eq(familyId),
+                            treatment.date.goe(LocalDateTime.now())
+                    )
+                    .orderBy(treatment.date.desc())
+                    .fetch();
+        } else {
+            return queryFactory
+                    .select(Projections.constructor(TreatmentItem.class,
+                            treatment.treatmentId,
+                            treatment.family.familyId,
+                            treatment.family.name,
+                            treatment.hospital.hospitalId,
+                            treatment.hospital.name,
+                            treatment.prescription.prescriptionId,
+                            treatment.department,
+                            treatment.date,
+                            treatment.taken,
+                            treatment.alarm,
+                            treatment.symptom))
+                    .from(treatment)
+                    .where(treatment.family.familyId.eq(familyId),
+                            treatment.date.lt(LocalDateTime.now())
+                    )
+                    .orderBy(treatment.date.desc())
+                    .fetch();
+        }
+    }
+
+    /**
+     * 가족 ID 집합으로 진료 조회 쿼리
+     *
+     * @param familyIds 가족 ID 목록
+     * @return 모든 진료 정보
+     */
+    public List<TreatmentItem> findTreatmentsByHospital(List<Long> familyIds) {
+        return queryFactory
+                .select(Projections.constructor(TreatmentItem.class,
+                        treatment.treatmentId,
+                        treatment.family.familyId,
+                        treatment.family.name,
+                        treatment.hospital.hospitalId,
+                        treatment.hospital.name,
+                        treatment.prescription.prescriptionId,
+                        treatment.department,
+                        treatment.date,
+                        treatment.taken,
+                        treatment.alarm,
+                        treatment.symptom))
+                .from(treatment)
+                .where(treatment.family.familyId.in(familyIds))
+                .fetch();
+    }
+
+    /**
+     * 가족 ID로 진료 조회 쿼리
+     *
+     * @param familyId 가족 ID
+     * @return 모든 진료 정보
+     */
+    public List<TreatmentItem> findFamilyTreatmentsByHospital(Long familyId) {
+        return queryFactory
+                .select(Projections.constructor(TreatmentItem.class,
+                        treatment.treatmentId,
+                        treatment.family.familyId,
+                        treatment.family.name,
+                        treatment.hospital.hospitalId,
+                        treatment.hospital.name,
+                        treatment.prescription.prescriptionId,
+                        treatment.department,
+                        treatment.date,
+                        treatment.taken,
+                        treatment.alarm,
+                        treatment.symptom))
+                .from(treatment)
+                .where(treatment.family.familyId.eq(familyId))
+                .fetch();
+    }
+
+    /**
+     * 가족 ID 집합으로 진료 조회 쿼리
+     *
+     * @param familyIds 가족 ID 목록
+     * @return 모든 진료 정보
+     */
+    public List<TreatmentItem> findTreatmentsByDate(List<Long> familyIds, int year, int month) {
+
+        DateTemplate<String> dateTemplate = Expressions.dateTemplate(String.class, "DATE_FORMAT({0}, '%Y-%m')", treatment.date);
+
+        return queryFactory
+                .select(Projections.constructor(TreatmentItem.class,
+                        treatment.treatmentId,
+                        treatment.family.familyId,
+                        treatment.family.name,
+                        treatment.hospital.hospitalId,
+                        treatment.hospital.name,
+                        treatment.prescription.prescriptionId,
+                        treatment.department,
+                        treatment.date,
+                        treatment.taken,
+                        treatment.alarm,
+                        treatment.symptom))
+                .from(treatment)
+                .where(treatment.family.familyId.in(familyIds),
+                        dateTemplate.eq(String.format("%d-%02d", year, month)))
+                // treatment.date.year().eq(year),
+                // treatment.date.month().eq(month)
+                .fetch();
+    }
+
+    /**
+     * 가족 ID 집합으로 진료 조회 쿼리
+     *
+     * @param familyId 가족 ID
+     * @return 모든 진료 정보
+     */
+    public List<TreatmentItem> findFamilyTreatmentsByDate(Long familyId, int year, int month) {
+
+        DateTemplate<String> dateTemplate = Expressions.dateTemplate(String.class, "DATE_FORMAT({0}, '%Y-%m')", treatment.date);
+
+        return queryFactory
+                .select(Projections.constructor(TreatmentItem.class,
+                        treatment.treatmentId,
+                        treatment.family.familyId,
+                        treatment.family.name,
+                        treatment.hospital.hospitalId,
+                        treatment.hospital.name,
+                        treatment.prescription.prescriptionId,
+                        treatment.department,
+                        treatment.date,
+                        treatment.taken,
+                        treatment.alarm,
+                        treatment.symptom))
+                .from(treatment)
+                .where(treatment.family.familyId.eq(familyId),
+                        dateTemplate.eq(String.format("%d-%02d", year, month)))
+                // treatment.date.year().eq(year),
+                // treatment.date.month().eq(month)
+                .fetch();
     }
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/service/TreatmentQueryService.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/service/TreatmentQueryService.java
@@ -1,10 +1,18 @@
 package com.wanchcoach.domain.treatment.service;
 
+import com.wanchcoach.domain.family.repository.query.FamilyQueryRepository;
+import com.wanchcoach.domain.treatment.controller.response.*;
 import com.wanchcoach.domain.treatment.repository.query.TreatmentQueryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 진료 조회 서비스
@@ -17,8 +25,129 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Transactional
 public class TreatmentQueryService {
+
     private final TreatmentQueryRepository treatmentQueryRepository;
+    private final FamilyQueryRepository familyQueryRepository;
+
     /**
-     * 진료 조회 API
+     * 회원 진료 조회 API
+     *
+     * @param memberId 회원 ID
+     * @return 계정에 등록된 모든 가족의 진료 정보
      */
+    public TreatmentResponse getTreatments(Long memberId) {
+        List<TreatmentItem> upcoming = treatmentQueryRepository.findTreatments(memberId, true);
+        List<TreatmentItem> past = treatmentQueryRepository.findTreatments(memberId, false);
+        return new TreatmentResponse(upcoming, past);
+    }
+
+    /**
+     * 가족 진료 조회 API
+     *
+     * @param familyId 가족 ID
+     * @return 계정에 등록된 모든 가족의 진료 정보
+     */
+    public TreatmentResponse getFamilyTreatments(Long familyId) {
+        List<TreatmentItem> upcoming = treatmentQueryRepository.findFamilyTreatments(familyId, true);
+        List<TreatmentItem> past = treatmentQueryRepository.findFamilyTreatments(familyId, false);
+        return new TreatmentResponse(upcoming, past);
+    }
+
+    /**
+     * 회원 진료 병원별 조회 API
+     *
+     * @param memberId 회원 ID
+     * @return 계정에 등록된 모든 가족의 병원별 진료 정보
+     */
+    public TreatmentHospitalResponse getTreatmentsByHospital(Long memberId) {
+
+        List<Long> familyIds = familyQueryRepository.findFamilyIdsByMemberId(memberId);
+        List<TreatmentItem> items = treatmentQueryRepository.findTreatmentsByHospital(familyIds);
+        List<TreatmentHospitalItem> hospitalItems = refineTreatmentItemsByHospital(items);
+
+        return new TreatmentHospitalResponse(hospitalItems);
+    }
+
+    /**
+     * 가족 진료 병원별 조회 API
+     *
+     * @param familyId 가족 ID
+     * @return 가족의 병원별 진료 정보
+     */
+    public TreatmentHospitalResponse getFamilyTreatmentsByHospital(Long familyId) {
+
+        List<TreatmentItem> items = treatmentQueryRepository.findFamilyTreatmentsByHospital(familyId);
+        List<TreatmentHospitalItem> hospitalItems = refineTreatmentItemsByHospital(items);
+
+        return new TreatmentHospitalResponse(hospitalItems);
+    }
+
+    /**
+     * 진료 목록 병원별로 변환
+     * 
+     * @param items 진료 목록
+     * @return 병원별로 그룹화한 진료 목록
+     */
+    private List<TreatmentHospitalItem> refineTreatmentItemsByHospital(List<TreatmentItem> items) {
+
+        // 1. 진료 목록을 hospitalId로 grouping
+        Map<Long, List<TreatmentItem>> groupedItems = items.stream()
+                .collect(Collectors.groupingBy(TreatmentItem::getHospitalId));
+
+        // 2. 진료 목록을 최신순(시간 내림차순)으로 정렬
+        groupedItems.forEach((hospitalId, treatmentItemList) -> Collections.sort(treatmentItemList));
+
+        // 3. 진료 횟수가 많은 병원 순으로 반환값 생성
+        return groupedItems.entrySet().stream()
+                .map(o -> new TreatmentHospitalItem(o.getKey(), o.getValue().get(0).getHospitalName(), o.getValue()))
+                .sorted((o1, o2) -> o2.getTreatmentItems().size() - o1.getTreatmentItems().size())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 회원 진료 월별 조회 API
+     *
+     * @param memberId 회원 ID
+     * @return 계정에 등록된 모든 가족의 월별 진료 정보
+     */
+    public TreatmentDateResponse getTreatmentsByDate(Long memberId, int year, int month) {
+
+        List<Long> familyIds = familyQueryRepository.findFamilyIdsByMemberId(memberId);
+        List<TreatmentItem> items = treatmentQueryRepository.findTreatmentsByDate(familyIds, year, month);
+        List<TreatmentDateItem> dateItems = refineTreatmentItemsByDate(items);
+
+        return new TreatmentDateResponse(dateItems);
+    }
+
+    /**
+     * 가족 진료 월별 조회 API
+     *
+     * @param familyId 가족 ID
+     * @return 가족의 월별 진료 정보
+     */
+    public TreatmentDateResponse getFamilyTreatmentsByDate(Long familyId, int year, int month) {
+
+        List<TreatmentItem> items = treatmentQueryRepository.findFamilyTreatmentsByDate(familyId, year, month);
+        List<TreatmentDateItem> dateItems = refineTreatmentItemsByDate(items);
+
+        return new TreatmentDateResponse(dateItems);
+    }
+
+    private List<TreatmentDateItem> refineTreatmentItemsByDate(List<TreatmentItem> items) {
+
+        // 1. 진료 목록을 날짜별로 grouping
+        Map<LocalDate, List<TreatmentItem>> groupedItems = items.stream()
+                .collect(Collectors.groupingBy(item -> item.getDate().toLocalDate()));
+
+        // 2. 진료 목록을 오래된 순(시간 오름차순)으로 정렬
+        groupedItems.forEach((date, treatmentItemList) -> Collections.sort(treatmentItemList, Collections.reverseOrder()));
+
+        // 3. 반환값 생성
+        return groupedItems.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(o -> new TreatmentDateItem(o.getKey(), o.getValue()))
+                .collect(Collectors.toList());
+    }
+
+
 }

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/service/TreatmentQueryService.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/service/TreatmentQueryService.java
@@ -140,7 +140,7 @@ public class TreatmentQueryService {
                 .collect(Collectors.groupingBy(item -> item.getDate().toLocalDate()));
 
         // 2. 진료 목록을 오래된 순(시간 오름차순)으로 정렬
-        groupedItems.forEach((date, treatmentItemList) -> Collections.sort(treatmentItemList, Collections.reverseOrder()));
+        groupedItems.forEach((date, treatmentItemList) -> treatmentItemList.sort(Collections.reverseOrder()));
 
         // 3. 반환값 생성
         return groupedItems.entrySet().stream()

--- a/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/service/TreatmentService.java
+++ b/wanchcoach/src/main/java/com/wanchcoach/domain/treatment/service/TreatmentService.java
@@ -74,7 +74,7 @@ public class TreatmentService {
         );
 
         // 진료 id 반환
-        return new CreateTreatmentResponse(savedTreatment.getId(), null);
+        return new CreateTreatmentResponse(savedTreatment.getTreatmentId(), null);
     }
 
     /**
@@ -106,7 +106,7 @@ public class TreatmentService {
         // 처방전 이미지 저장
         String fileName = familyQueryRepository.findNameById(dto.familyId()) +
                 "_" +
-                prescription.getId() +
+                prescription.getPrescriptionId() +
                 "_" +
                 prescription.getModifiedDate().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) +
                 "." +
@@ -142,6 +142,6 @@ public class TreatmentService {
          */
 
         // 처방전 id 반환
-        return new CreatePrescriptionResponse(prescription.getId());
+        return new CreatePrescriptionResponse(prescription.getPrescriptionId());
     }
 }

--- a/wanchcoach/src/main/resources/ddl_240610.sql
+++ b/wanchcoach/src/main/resources/ddl_240610.sql
@@ -9,7 +9,7 @@ CREATE TABLE `member` (
 	`name`	VARCHAR(30)	NOT NULL,
 	`email`	VARCHAR(100)	NOT NULL,
 	`birth_date`	DATE	NOT NULL,
-	`gender`	TINYINT	NOT NULL,
+	`gender`	VARCHAR(1)	NOT NULL,
 	`phone_number`	VARCHAR(30)	NOT NULL,
 	`active`	TINYINT	NOT NULL,
 	`refresh_token`	VARCHAR(255) 	NULL,
@@ -30,7 +30,7 @@ CREATE TABLE `member_device_token` (
 );
 
 CREATE TABLE `family` (
-	`family_id`	BIGINT 	PRIMARY KEY,
+	`family_id`	BIGINT 	AUTO_INCREMENT PRIMARY KEY,
 	`member_id`	BIGINT 	NOT NULL,
 	`name`	VARCHAR(30)	NOT NULL,
 	`birth_date`	DATE	NOT NULL,
@@ -141,8 +141,7 @@ CREATE TABLE `pharmacy` (
 	`phone_number`	VARCHAR(30)	NOT NULL,
 	`longitude`	DECIMAL(15, 12)	NOT NULL,
 	`latitude`	DECIMAL(15, 13)	NOT NULL,
-	`post_cdn1`	INT	NOT NULL,
-	`post_cdn2`	INT	NOT NULL,
+	`post_cdn`	VARCHAR(5)	NOT NULL,
     `created_date`  DATETIME NOT NULL DEFAULT NOW(),
     `modified_date` DATETIME NOT NULL DEFAULT NOW()
 );
@@ -164,8 +163,7 @@ CREATE TABLE `hospital` (
 	`phone_number`	VARCHAR(30)	NOT NULL,
 	`longitude`	DECIMAL(15, 12)	NOT NULL,
 	`latitude`	DECIMAL(15, 13)	NOT NULL,
-	`post_cdn1`	INT	NOT NULL,
-	`post_cdn2`	INT	NOT NULL,
+    `post_cdn`	VARCHAR(5)	NOT NULL,
     `created_date`  DATETIME NOT NULL DEFAULT NOW(),
     `modified_date` DATETIME NOT NULL DEFAULT NOW()
 );
@@ -321,17 +319,28 @@ REFERENCES `drug` (
 	`drug_id`
 );
 
-insert into `member` (id, encrypted_pwd, name, email, birth_date, gender, phone_number, active, refresh_token, login_type)
-values (1, 'test_pwd', '유호재', 'ho_0214@naver.com', now(), 0, '010-7226-0214', true, 'test_token', 1);
+insert into wanchcoach.member (member_id, id, encrypted_pwd, name, email, birth_date, gender, phone_number, active, refresh_token, login_type, location_permission, call_permission, camera_permission, created_date, modified_date)
+values  (1, '1', 'test_pwd', '유호재', 'ho_0214@naver.com', '2024-06-13', 'M', '010-7226-0214', 1, 'test_token', 1, 0, 0, 0, '2024-06-13 22:25:06', '2024-06-13 22:25:06'),
+        (2, '2', 'test_pwd', '신규람', 'gyulife@naver.com', '1998-01-01', 'M', '010-1234-5678', 1, 'test_token2', 0, 1, 1, 1, '2024-06-15 04:44:55', '2024-06-15 04:44:55');
 
-insert into `family` (family_id, member_id, name, birth_date, gender, image_file_name)
-values (1, 1, '유호재', now(), 0, 'test_image_file_name');
+insert into wanchcoach.family (family_id, member_id, name, birth_date, gender, image_file_name, created_date, modified_date)
+values  (1, 1, '유호재', '2024-06-13', 'M', 'test_image_file_name', '2024-06-13 22:25:06', '2024-06-13 22:25:06'),
+        (2, 2, '신규람', '1998-01-01', 'M', null, '2024-06-15 04:45:47', '2024-06-15 04:45:47'),
+        (3, 1, '배용현', '1998-01-02', 'M', null, '2024-06-15 05:22:59', '2024-06-15 05:22:59'),
+        (4, 1, '나종현', '1998-01-03', 'M', null, '2024-06-15 05:22:59', '2024-06-15 05:22:59'),
+        (5, 1, '곽강한', '1995-01-01', 'F', null, '2024-06-15 05:22:59', '2024-06-15 05:22:59'),
+        (6, 2, '신호인', '1997-01-01', 'M', null, '2024-06-15 05:22:59', '2024-06-15 05:22:59'),
+        (7, 2, '홍진식', '2024-06-15', 'F', null, '2024-06-15 05:22:59', '2024-06-15 05:22:59');
 
-insert into `hospital` (hospital_id, name, address, phone_number, longitude, latitude, post_cdn1, post_cdn2)
-values (1, '세브란스병원', '광주광역시 광산구 첨단과기로', '010-2638-5572', 126.833009748716, 35.2271203871567, 622, 53);
+insert into wanchcoach.hospital (hospital_id, name, address, phone_number, longitude, latitude, post_cdn, created_date, modified_date)
+values  (1, '세브란스병원', '광주광역시 광산구 첨단과기로', '010-2638-5572', 126.833009748716, 35.2271203871567, '62253', '2024-06-13 22:25:06', '2024-06-13 22:25:06'),
+        (2, '가톨릭대학교 성빈센트병원', '경기도 수원시 팔달구 중부대로 93, (지동)', '031-1577-8588', 127.027427100000, 37.2779855000000, '16247', '2024-06-15 04:42:45', '2024-06-15 04:42:45'),
+        (3, '강릉아산병원', '강원특별자치도 강릉시 사천면 방동길 38', '033-610-3114', 128.857841100000, 37.8184325000000, '25440', '2024-06-15 04:42:45', '2024-06-15 04:42:45'),
+        (4, '강북삼성병원', '서울특별시 종로구 새문안로 29', '02-2001-2001', 126.967750000000, 37.5684083000000, '03181', '2024-06-15 04:42:45', '2024-06-15 04:42:45'),
+        (5, '건국대학교병원', '서울특별시 광진구 능동로 120-1', '1588-1533', 127.071827600000, 37.5403764000000, '05030', '2024-06-15 04:42:45', '2024-06-15 04:42:45');
 
-insert into `pharmacy` (pharmacy_id, name, address, phone_number, longitude, latitude, post_cdn1, post_cdn2, created_date, modified_date)
-values (1, '종현약국', '서울특별시 관악구 봉천동', '010-4064-3297', 126.941892000000, 37.4823620000000, '559', '48', '2024-06-13 20:45:22', '2024-06-13 20:45:22');
+insert into wanchcoach.pharmacy (pharmacy_id, name, address, phone_number, longitude, latitude, post_cdn, created_date, modified_date)
+values  (1, '나종현국', '서울특별시 관악구 봉천동', '010-9876-5432', 132.000000000000, 37.0000000000000, '01234', '2024-06-15 05:26:59', '2024-06-15 05:26:59');
 
 insert into `drug category` (drug_cat_id, name, created_date, modified_date) values (1, '진통제', '2024-06-13 20:42:32', '2024-06-13 20:42:32');
 insert into `drug category` (drug_cat_id, name, created_date, modified_date) values (2, '소염제', '2024-06-13 20:42:32', '2024-06-13 20:42:32');
@@ -339,4 +348,22 @@ insert into `drug category` (drug_cat_id, name, created_date, modified_date) val
 insert into `drug` (drug_id, drug_cat_id, manufacturer, name, efficacy, ingredient, image_file_name, created_date, modified_date) values (1, 1, '규람제약', '규라미논', '모든 고통을 없애줍니다.', '규라미산나트륨', null, '2024-06-13 20:43:43', '2024-06-13 20:43:43');
 insert into `drug` (drug_id, drug_cat_id, manufacturer, name, efficacy, ingredient, image_file_name, created_date, modified_date) values (2, 2, '호제약', '호재신', '모든 염증을 없애줍니다.', '호재산칼륨', null, '2024-06-13 20:43:43', '2024-06-13 20:43:43');
 
+insert into wanchcoach.prescription (prescription_id, pharmacy_id, remains, taking, end_date, image_file_name, created_date, modified_date)
+values  (1, 1, 9, 1, null, null, '2024-06-15 05:20:40', '2024-06-15 05:20:40'),
+        (2, 1, 6, 1, null, null, '2024-06-15 05:20:57', '2024-06-15 05:20:57');
 
+insert into wanchcoach.treatment (treatment_id, family_id, hospital_id, prescription_id, department, date, taken, alarm, symptom, created_date, modified_date)
+values  (1, 1, 1, 1, '내과', '2024-04-30 00:00:00', 1, 1, '복통', '2024-06-13 22:25:18', '2024-06-13 22:25:19'),
+        (2, 1, 1, 2, '내과', '2024-05-01 00:00:00', 1, 1, '복통', '2024-06-13 22:42:42', '2024-06-13 22:42:43'),
+        (3, 2, 1, null, '비뇨기과', '2024-05-02 00:00:00', 1, 1, '고환통', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (4, 2, 3, null, '피부과', '2024-06-30 00:00:00', 0, 1, '여드름', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (5, 2, 4, null, '내과', '2024-05-15 00:00:00', 1, 1, '복통', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (6, 3, 2, null, '피부과', '2024-05-22 00:00:00', 1, 1, '종기', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (7, 3, 3, null, '정형외과', '2024-06-16 00:00:00', 0, 1, '무릎 통증', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (8, 4, 1, null, '이비인후과', '2024-05-17 00:00:00', 1, 1, '코막힘', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (9, 5, 5, null, '피부과', '2024-06-20 00:00:00', 0, 1, '뾰루지', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (10, 6, 5, null, '이비인후과', '2024-04-30 00:00:00', 1, 1, '기침', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (11, 6, 2, null, '이비인후과', '2024-05-20 00:00:00', 1, 1, '인후통', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (12, 6, 3, null, '외과', '2024-06-27 00:00:00', 0, 1, '베임', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (13, 7, 4, null, '외과', '2024-06-01 00:00:00', 1, 1, '욕창', '2024-06-15 04:53:41', '2024-06-15 04:53:41'),
+        (14, 7, 4, null, '비뇨기과', '2024-07-01 00:00:00', 0, 1, '포경수술', '2024-06-15 04:53:41', '2024-06-15 04:53:41');


### PR DESCRIPTION
## DONE
- 진료 조회(계정에 등록된 전체 가족 조회/특정 가족 조회 중 택 1) & (일반 조회/병원별 조회/월별 조회 중 택 1)
- 엔티티 id 속성명 통일(엔티티명+Id)
- DDL 수정(우편번호 속성 2개 -> 1개로 변경 등) + DML 추가
<br>

## 🔧 TODO
- 계정에 등록된 전체 가족 ID 조회 로직에서 액세스 토큰으로 계정 정보 가져오는 로직 구현 필요
- 조건별 진료 조회 로직 개선의 여지
<br>

## 📝 리뷰할 때 참고할 점
- 메서드명이 지저분해졌는데, 좋은 아이디어 있으시면 댓글 남겨주세요!
- Controller / Repository / Service 단에서 CRUD 메서드명(make/create, get/update, modify/update, remove/delete 등)을 어떻게 하면 좋을까요?
- 현재 컨트롤러 패키지 구조가 controller 폴더 밑에 request/response 폴더와 컨트롤러 클래스로 구성되어 있는데,
request/response 위에 dto 폴더를 놓아서 dto 안에 request와 response 폴더가 저장되도록 수정할까요?
